### PR TITLE
Require CGI

### DIFF
--- a/lib/fat_zebra.rb
+++ b/lib/fat_zebra.rb
@@ -3,6 +3,7 @@ require 'securerandom'
 require 'json'
 require 'ostruct'
 require 'net/http'
+require 'cgi'
 
 require 'fat_zebra/version'
 require 'fat_zebra/util'

--- a/lib/fat_zebra.rb
+++ b/lib/fat_zebra.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'ostruct'
 require 'net/http'
 require 'cgi'
+require 'date'
 
 require 'fat_zebra/version'
 require 'fat_zebra/util'


### PR DESCRIPTION
Without this, in a bare-bones example I get

````
/Users/keith.broughton/.rbenv/versions/2.3.5/lib/ruby/gems/2.3.0/gems/fat_zebra-3.0.6/lib/fat_zebra/api_helper.rb:17:in `resource_path': uninitialized constant FatZebra::APIHelper::ClassMethods::CGI (NameError)
	from /Users/keith.broughton/.rbenv/versions/2.3.5/lib/ruby/gems/2.3.0/gems/fat_zebra-3.0.6/lib/fat_zebra/api_operation/find.rb:18:in `find'
	from lib/test.rb:9:in `<main>'
````