### PR TITLE
Fix query params and enable query testing

### DIFF
--- a/fat_zebra.gemspec
+++ b/fat_zebra.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'fat_zebra/version'

--- a/lib/fat_zebra/request.rb
+++ b/lib/fat_zebra/request.rb
@@ -80,7 +80,7 @@ module FatZebra
     end
 
     def get
-      @request = Net::HTTP::Get.new(uri.path)
+      @request = Net::HTTP::Get.new(uri)
 
       setup_auth_basic if params[:basic_auth]
       set_header

--- a/spec/lib/fat_zebra/purchase_spec.rb
+++ b/spec/lib/fat_zebra/purchase_spec.rb
@@ -44,7 +44,7 @@ describe FatZebra::Purchase do
   end
 
   describe '.search', :vcr do
-    let!(:start) { Time.now }
+    let!(:start) { Date.parse('2017-07-03') }
     subject(:purchases) { FatZebra::Purchase.search(from: start) }
 
     before { 2.times { |i| FatZebra::Purchase.create(valid_purchase_payload.merge(reference: "#{SecureRandom.hex}-#{i}")) } }
@@ -95,7 +95,7 @@ describe FatZebra::Purchase do
   describe '.settlement', :vcr do
     before { 2.times { |i| FatZebra::Purchase.create(valid_purchase_payload.merge(reference: "#{SecureRandom.hex}-#{i}")) } }
 
-    subject(:settlement) { FatZebra::Purchase.settlement(from: Time.now - (86400 * 5), to: Time.now) }
+    subject(:settlement) { FatZebra::Purchase.settlement(from: Date.parse('2017/06/22'), to: Date.parse('2017-06-27')) }
 
     it { is_expected.to be_accepted }
     it { expect(settlement.data.count).to be >= 2 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,7 @@ VCR.configure do |config|
   config.hook_into :webmock
   config.configure_rspec_metadata!
   config.allow_http_connections_when_no_cassette = true
-  config.default_cassette_options = { match_requests_on: [:method, uri_ignoring_trailing_id] }
+  config.default_cassette_options = { match_requests_on: [:method, :query, uri_ignoring_trailing_id] }
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Regressed in 3.0.6 - https://github.com/fatzebra/Ruby-Library/commit/bc3056c9bc0067259a962bccd002c853b27bb28e

We're not sending query params in GET requests.

* update the vcr tests to verify the query params
* update the tests to be time independent
* fix the bug