### PR TITLE
Enforce float for direct entries

### DIFF
--- a/lib/fat_zebra/direct_credit.rb
+++ b/lib/fat_zebra/direct_credit.rb
@@ -17,7 +17,7 @@ module FatZebra
     include FatZebra::APIOperation::Delete
 
     validates :description, required: true, on: :create
-    validates :amount, required: true, type: :positive_numeric, on: :create
+    validates :amount, required: true, type: :positive_float, on: :create
     validates :bsb, required: true, on: :create
     validates :account_name, required: true, on: :create
     validates :account_number, required: true, on: :create

--- a/lib/fat_zebra/direct_debit.rb
+++ b/lib/fat_zebra/direct_debit.rb
@@ -17,7 +17,7 @@ module FatZebra
     include FatZebra::APIOperation::Delete
 
     validates :description, required: true, on: :create
-    validates :amount, required: true, type: :positive_numeric, on: :create
+    validates :amount, required: true, type: :positive_float, on: :create
     validates :bsb, required: true, on: :create
     validates :account_name, required: true, on: :create
     validates :account_number, required: true, on: :create

--- a/lib/fat_zebra/validation.rb
+++ b/lib/fat_zebra/validation.rb
@@ -39,9 +39,12 @@ module FatZebra
       errors << "'#{field}' is required" if params[field].nil? || params[field] == ''
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def validate_type(field, options, params)
       regexp =
         case options
+        when :positive_float
+          /\A\d*\.\d+\z/
         when :positive_numeric
           /\A\d*\.?\d+\z/
         when :positive_integer
@@ -58,6 +61,7 @@ module FatZebra
 
       errors << "'#{field}' is not a '#{options}'" unless params[field].to_s =~ regexp
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
   end
 end

--- a/spec/cassettes/FatZebra_DirectCredit/_find/1_2_3.yml
+++ b/spec/cassettes/FatZebra_DirectCredit/_find/1_2_3.yml
@@ -1,0 +1,103 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://gateway.sandbox.fatzebra.com.au/v1.0/direct_credits
+    body:
+      encoding: UTF-8
+      string: '{"description":"Confirmation","amount":42.0,"bsb":"123-123","account_name":"Test","account_number":"012345678","test":true}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic VEVTVDpURVNU
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 24 Oct 2018 01:05:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 201 Created
+      Cache-Control:
+      - no-store
+      X-Request-Version:
+      - 1.16.9-3627@3b72f16
+      X-Runtime:
+      - '0.046561'
+      Pragma:
+      - no-cache
+      X-Request-Id:
+      - dfc4dfbf553aeafe9f0b09fa
+      X-Backend:
+      - sbox-priv-gateway-a
+    body:
+      encoding: UTF-8
+      string: '{"successful":true,"response":{"id":"071-DC-UTVNLTGW","amount":42.0,"bsb":"123-123","account_number":"012345678","account_name":"Test","description":"Confirmation","reference":"071-DC-UTVNLTGW","date":"2018-10-24","process_date":null,"status":"New","result":null,"metadata":null},"errors":[],"test":true}'
+    http_version: 
+  recorded_at: Wed, 24 Oct 2018 01:05:21 GMT
+- request:
+    method: get
+    uri: https://gateway.sandbox.fatzebra.com.au/v1.0/direct_credits/071-DC-UTVNLTGW?test=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Host:
+      - gateway.sandbox.fatzebra.com.au
+      Authorization:
+      - Basic VEVTVDpURVNU
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Oct 2018 01:05:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-store
+      X-Request-Version:
+      - 1.16.9-3627@3b72f16
+      X-Runtime:
+      - '0.022300'
+      Pragma:
+      - no-cache
+      X-Request-Id:
+      - '09fe4ae9951d44174ee56bdc'
+      X-Backend:
+      - sbox-priv-gateway-a
+    body:
+      encoding: UTF-8
+      string: '{"successful":true,"response":{"id":"071-DC-UTVNLTGW","amount":42.0,"bsb":"123-123","account_number":"012345678","account_name":"Test","description":"Confirmation","reference":"071-DC-UTVNLTGW","date":"2018-10-24","process_date":null,"status":"New","result":null,"metadata":null},"errors":[],"test":true}'
+    http_version: 
+  recorded_at: Wed, 24 Oct 2018 01:05:21 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/FatZebra_DirectDebit/_create/validations/failed_with_non-float/1_1_5_3_1.yml
+++ b/spec/cassettes/FatZebra_DirectDebit/_create/validations/failed_with_non-float/1_1_5_3_1.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://gateway.sandbox.fatzebra.com.au/v1.0/direct_debits
+    body:
+      encoding: UTF-8
+      string: '{"description":"Confirmation","amount":123,"bsb":"123-123","account_name":"Test","account_number":"012345678","test":true}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic VEVTVDpURVNU
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 24 Oct 2018 01:02:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 201 Created
+      Cache-Control:
+      - no-store
+      X-Request-Version:
+      - 1.16.9-3627@3b72f16
+      X-Runtime:
+      - '0.051478'
+      Pragma:
+      - no-cache
+      X-Request-Id:
+      - 8c0141486f43f0bace8e32fc
+      X-Backend:
+      - sbox-priv-gateway-a
+    body:
+      encoding: UTF-8
+      string: '{"successful":true,"response":{"id":"071-DD-5SPL2753","amount":123.0,"bsb":"123-123","account_number":"012345678","account_name":"Test","description":"Confirmation","reference":"071-DD-5SPL2753","date":"2018-10-24","process_date":null,"status":"New","result":null,"metadata":null},"errors":[],"test":true}'
+    http_version: 
+  recorded_at: Wed, 24 Oct 2018 01:02:52 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/FatZebra_DirectDebit/_find/1_2_3.yml
+++ b/spec/cassettes/FatZebra_DirectDebit/_find/1_2_3.yml
@@ -1,0 +1,103 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://gateway.sandbox.fatzebra.com.au/v1.0/direct_debits
+    body:
+      encoding: UTF-8
+      string: '{"description":"Confirmation","amount":42.0,"bsb":"123-123","account_name":"Test","account_number":"012345678","test":true}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic VEVTVDpURVNU
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 24 Oct 2018 01:03:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 201 Created
+      Cache-Control:
+      - no-store
+      X-Request-Version:
+      - 1.16.9-3627@3b72f16
+      X-Runtime:
+      - '0.043132'
+      Pragma:
+      - no-cache
+      X-Request-Id:
+      - 4fd3db08dbdb1a6c6f912bc8
+      X-Backend:
+      - sbox-priv-gateway-a
+    body:
+      encoding: UTF-8
+      string: '{"successful":true,"response":{"id":"071-DD-5M1TDSVX","amount":42.0,"bsb":"123-123","account_number":"012345678","account_name":"Test","description":"Confirmation","reference":"071-DD-5M1TDSVX","date":"2018-10-24","process_date":null,"status":"New","result":null,"metadata":null},"errors":[],"test":true}'
+    http_version: 
+  recorded_at: Wed, 24 Oct 2018 01:03:29 GMT
+- request:
+    method: get
+    uri: https://gateway.sandbox.fatzebra.com.au/v1.0/direct_debits/071-DD-5M1TDSVX?test=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Host:
+      - gateway.sandbox.fatzebra.com.au
+      Authorization:
+      - Basic VEVTVDpURVNU
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Oct 2018 01:03:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-store
+      X-Request-Version:
+      - 1.16.9-3627@3b72f16
+      X-Runtime:
+      - '0.015420'
+      Pragma:
+      - no-cache
+      X-Request-Id:
+      - 531343808d0ee26096fc2938
+      X-Backend:
+      - sbox-priv-gateway-a
+    body:
+      encoding: UTF-8
+      string: '{"successful":true,"response":{"id":"071-DD-5M1TDSVX","amount":42.0,"bsb":"123-123","account_number":"012345678","account_name":"Test","description":"Confirmation","reference":"071-DD-5M1TDSVX","date":"2018-10-24","process_date":null,"status":"New","result":null,"metadata":null},"errors":[],"test":true}'
+    http_version: 
+  recorded_at: Wed, 24 Oct 2018 01:03:29 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/fat_zebra/direct_credit_spec.rb
+++ b/spec/lib/fat_zebra/direct_credit_spec.rb
@@ -4,7 +4,7 @@ describe FatZebra::DirectCredit do
 
   let(:valid_direct_credit_payload) {{
     description:    'Confirmation',
-    amount:         42,
+    amount:         42.0,
     bsb:            '123-123',
     account_name:   'Test',
     account_number: '012345678'
@@ -27,6 +27,18 @@ describe FatZebra::DirectCredit do
 
       context 'failed' do
         let(:valid_direct_credit_payload) {{}}
+
+        it { expect{ direct_credit }.to raise_error(FatZebra::RequestValidationError) }
+      end
+
+      context 'failed with non-float' do
+        let(:valid_direct_credit_payload) {{
+          description:    'Confirmation',
+          amount:         123,
+          bsb:            '123-123',
+          account_name:   'Test',
+          account_number: '012345678'
+        }}
 
         it { expect{ direct_credit }.to raise_error(FatZebra::RequestValidationError) }
       end

--- a/spec/lib/fat_zebra/direct_credit_spec.rb
+++ b/spec/lib/fat_zebra/direct_credit_spec.rb
@@ -51,6 +51,7 @@ describe FatZebra::DirectCredit do
 
     it { is_expected.to be_accepted }
     it { expect(direct_credit.reference).to eq(create.reference) }
+    it { expect(direct_credit.amount).to be_instance_of(Float) }
   end
 
   describe '.search', :vcr do

--- a/spec/lib/fat_zebra/direct_debit_spec.rb
+++ b/spec/lib/fat_zebra/direct_debit_spec.rb
@@ -51,6 +51,7 @@ describe FatZebra::DirectDebit do
 
     it { is_expected.to be_accepted }
     it { expect(direct_debit.reference).to eq(create.reference) }
+    it { expect(direct_debit.amount).to be_instance_of(Float) }
   end
 
   describe '.search', :vcr do

--- a/spec/lib/fat_zebra/direct_debit_spec.rb
+++ b/spec/lib/fat_zebra/direct_debit_spec.rb
@@ -4,7 +4,7 @@ describe FatZebra::DirectDebit do
 
   let(:valid_direct_debit_payload) {{
     description:    'Confirmation',
-    amount:         42,
+    amount:         42.0,
     bsb:            '123-123',
     account_name:   'Test',
     account_number: '012345678'
@@ -27,6 +27,18 @@ describe FatZebra::DirectDebit do
 
       context 'failed' do
         let(:valid_direct_debit_payload) {{}}
+
+        it { expect{ direct_debit }.to raise_error(FatZebra::RequestValidationError) }
+      end
+
+      context 'failed with non-float' do
+        let(:valid_direct_debit_payload) {{
+          description:    'Confirmation',
+          amount:         123,
+          bsb:            '123-123',
+          account_name:   'Test',
+          account_number: '012345678'
+        }}
 
         it { expect{ direct_debit }.to raise_error(FatZebra::RequestValidationError) }
       end


### PR DESCRIPTION
To avoid ambiguity we need to ensure that the value provided for a DD or DC is a float and not an integer.