### PR TITLE
Add find method to FatZebra::Card

### DIFF
--- a/lib/fat_zebra/card.rb
+++ b/lib/fat_zebra/card.rb
@@ -9,6 +9,7 @@ module FatZebra
   class Card < APIResource
     @resource_name = 'credit_cards'
 
+    include FatZebra::APIOperation::Find
     include FatZebra::APIOperation::Save
 
     validates :card_holder, required: { unless: %i[wallet] }, on: :create

--- a/spec/cassettes/FatZebra_Card/_find/1_3_1.yml
+++ b/spec/cassettes/FatZebra_Card/_find/1_3_1.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://gateway.sandbox.fatzebra.com.au/v1.0/credit_cards
+    body:
+      encoding: UTF-8
+      string: '{"card_holder":"Matthew Savage","card_number":"5123456789012346","card_expiry":"02/2030","cvv":123,"test":true}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic VEVTVDpURVNU
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 10 Jun 2020 06:59:24 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-store
+      X-Request-Version:
+      - 1.21.8
+      X-Runtime:
+      - '0.319736'
+      Pragma:
+      - no-cache
+      X-Request-Id:
+      - f6b8f8d29b19d3ad76bfe293
+      X-Backend:
+      - gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"successful":true,"response":{"token":"awy21sdeq8og9wxwk2dl","card_holder":"Matthew
+        Savage","card_number":"512345XXXXXX2346","card_expiry":"2030-02-28","card_type":"MasterCard","card_category":"Credit","card_subcategory":"Standard","card_issuer":"Afriland
+        First Bank","card_country":"Benin","authorized":true,"transaction_count":0,"alias":null},"errors":[],"test":true}'
+    http_version: 
+  recorded_at: Wed, 10 Jun 2020 06:59:24 GMT
+- request:
+    method: get
+    uri: https://gateway.sandbox.fatzebra.com.au/v1.0/credit_cards/awy21sdeq8og9wxwk2dl?test=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Host:
+      - gateway.sandbox.fatzebra.com.au
+      Authorization:
+      - Basic VEVTVDpURVNU
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 10 Jun 2020 06:59:24 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-store
+      X-Request-Version:
+      - 1.21.8
+      X-Runtime:
+      - '0.013428'
+      Pragma:
+      - no-cache
+      X-Request-Id:
+      - 7287ce40a99b0454d28eb1fc
+      X-Backend:
+      - gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"successful":true,"response":{"token":"awy21sdeq8og9wxwk2dl","card_holder":"Matthew
+        Savage","card_number":"512345XXXXXX2346","card_expiry":"2030-02-28","card_type":"MasterCard","card_category":"Credit","card_subcategory":"Standard","card_issuer":"Afriland
+        First Bank","card_country":"Benin","authorized":true,"transaction_count":0,"alias":null},"errors":[],"test":true}'
+    http_version: 
+  recorded_at: Wed, 10 Jun 2020 06:59:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/FatZebra_Card/_find/1_3_2.yml
+++ b/spec/cassettes/FatZebra_Card/_find/1_3_2.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://gateway.sandbox.fatzebra.com.au/v1.0/credit_cards
+    body:
+      encoding: UTF-8
+      string: '{"card_holder":"Matthew Savage","card_number":"5123456789012346","card_expiry":"02/2030","cvv":123,"test":true}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic VEVTVDpURVNU
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 10 Jun 2020 06:59:24 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-store
+      X-Request-Version:
+      - 1.21.8
+      X-Runtime:
+      - '0.315215'
+      Pragma:
+      - no-cache
+      X-Request-Id:
+      - e7dcee7439ed04a0b1eea668
+      X-Backend:
+      - gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"successful":true,"response":{"token":"o723qqzihmdogtbe1yz7","card_holder":"Matthew
+        Savage","card_number":"512345XXXXXX2346","card_expiry":"2030-02-28","card_type":"MasterCard","card_category":"Credit","card_subcategory":"Standard","card_issuer":"Afriland
+        First Bank","card_country":"Benin","authorized":true,"transaction_count":0,"alias":null},"errors":[],"test":true}'
+    http_version: 
+  recorded_at: Wed, 10 Jun 2020 06:59:25 GMT
+- request:
+    method: get
+    uri: https://gateway.sandbox.fatzebra.com.au/v1.0/credit_cards/o723qqzihmdogtbe1yz7?test=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Host:
+      - gateway.sandbox.fatzebra.com.au
+      Authorization:
+      - Basic VEVTVDpURVNU
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 10 Jun 2020 06:59:25 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-store
+      X-Request-Version:
+      - 1.21.8
+      X-Runtime:
+      - '0.013891'
+      Pragma:
+      - no-cache
+      X-Request-Id:
+      - 67099342b9cfd39845f5a7fa
+      X-Backend:
+      - gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"successful":true,"response":{"token":"o723qqzihmdogtbe1yz7","card_holder":"Matthew
+        Savage","card_number":"512345XXXXXX2346","card_expiry":"2030-02-28","card_type":"MasterCard","card_category":"Credit","card_subcategory":"Standard","card_issuer":"Afriland
+        First Bank","card_country":"Benin","authorized":true,"transaction_count":0,"alias":null},"errors":[],"test":true}'
+    http_version: 
+  recorded_at: Wed, 10 Jun 2020 06:59:25 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/fat_zebra/card_spec.rb
+++ b/spec/lib/fat_zebra/card_spec.rb
@@ -38,4 +38,12 @@ describe FatZebra::Card do
     end
   end
 
+  describe '.find', :vcr do
+    let(:create) { FatZebra::Card.create(valid_credit_card_payload) }
+    subject(:card) { FatZebra::Card.find(create.token) }
+
+    it { is_expected.to be_accepted }
+    it { expect(card.token).to eq(create.token) }
+  end
+
 end


### PR DESCRIPTION
We want to be able to use the type (MasterCard, Visa, etc.) from a card stored with a token but we are only able to do this if we fetch the card (https://docs.cloudpayments.io/reference#fetch-a-tokenized-card).

Also closes issue https://github.com/fatzebra/Ruby-Library/issues/22