### PR TITLE
Fixes for buildkite gem releasing

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,6 +25,10 @@ steps:
     plugins:
       - docker#v3.3.0:
           image: ruby:2.7
+          environment:
+            - GEM_HOST_API_KEY
+            - GIT_AUTHOR_NAME=Fat Zebra
+            - GIT_AUTHOR_EMAIL=support@fatzebra.com
     agents:
       queue: aws
       Environment: test


### PR DESCRIPTION
Make sure we forward GEM_HOST_API_KEY and GIT_AUTHOR_* env vars onto the docker container