### PR TITLE
[DASH-2880] Expose Apple Pay (web) list domains logic

### DIFF
--- a/lib/fat_zebra/utilities/apple_pay/domain.rb
+++ b/lib/fat_zebra/utilities/apple_pay/domain.rb
@@ -13,7 +13,7 @@ module FatZebra
           # List Apple Pay (web) domains
           #
           # @return [FatZebra::Utilities::ApplePay::Domains] response
-          def list!
+          def list
             response = request(:get, ENDPOINT_URL)
             initialize_from(response)
           end

--- a/lib/fat_zebra/utilities/apple_pay/domain.rb
+++ b/lib/fat_zebra/utilities/apple_pay/domain.rb
@@ -10,6 +10,15 @@ module FatZebra
         class << self
 
           ##
+          # List Apple Pay (web) domains
+          #
+          # @return [FatZebra::Utilities::ApplePay::Domains] response
+          def list!
+            response = request(:get, ENDPOINT_URL)
+            initialize_from(response)
+          end
+
+          ##
           # Register an Apple Pay (web) domain
           #
           # @return [FatZebra::Utilities::ApplePay::Domains] response

--- a/spec/cassettes/FatZebra_Utilities_ApplePay_Domain/_list/fetches_the_merchant_domains.yml
+++ b/spec/cassettes/FatZebra_Utilities_ApplePay_Domain/_list/fetches_the_merchant_domains.yml
@@ -25,7 +25,7 @@ http_interactions:
         message: OK
       headers:
         Date:
-          - Tue, 26 Mar 2024 03:14:05 GMT
+          - Wed, 27 Mar 2024 05:15:56 GMT
         Content-Type:
           - application/json; charset=utf-8
         Transfer-Encoding:
@@ -41,9 +41,9 @@ http_interactions:
         Pragma:
           - no-cache
         X-Request-Id:
-          - "099b4535179e7514792bf224"
+          - 2cbc832327aa693a5e85b23b
         X-Runtime:
-          - "0.065136"
+          - "0.062169"
         X-Backend:
           - gateway
         Strict-Transport-Security:
@@ -82,5 +82,5 @@ http_interactions:
         encoding: UTF-8
         string: '{"successful":true,"response":[{"domain":"example.com","status":"Active"},{"domain":"example2.com","status":"Active"}],"errors":[],"test":true}'
       http_version:
-    recorded_at: Tue, 26 Mar 2024 03:14:05 GMT
+    recorded_at: Wed, 27 Mar 2024 05:15:56 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/FatZebra_Utilities_ApplePay_Domain/_list_/fetches_the_merchant_domains.yml
+++ b/spec/cassettes/FatZebra_Utilities_ApplePay_Domain/_list_/fetches_the_merchant_domains.yml
@@ -1,0 +1,86 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://gateway.sandbox.fatzebra.com.au/v1.0/utilities/apple_pay/domains?test=true
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - application/json
+        User-Agent:
+          - Ruby
+        Host:
+          - gateway.sandbox.fatzebra.com.au
+        Authorization:
+          - Basic VEVTVDpURVNU
+        Content-Type:
+          - application/json
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Tue, 26 Mar 2024 03:14:05 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Status:
+          - 200 OK
+        Cache-Control:
+          - no-store
+        Vary:
+          - Accept
+        Pragma:
+          - no-cache
+        X-Request-Id:
+          - "099b4535179e7514792bf224"
+        X-Runtime:
+          - "0.065136"
+        X-Backend:
+          - gateway
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+        Content-Security-Policy-Report-Only:
+          - "child-src 'self' blob: *.cardinalcommerce.com fatzebra.statuspage.io; connect-src
+            'self' *.mastercard.com *.forter.com *.pmnts-staging.io *.rollbar.com *.nr-data.net
+            *.cardinalcommerce.com fatzebra.statuspage.io *.googleapis.com *.google-analytics.com;
+            default-src 'self' 'unsafe-eval' 'unsafe-inline' *.forter.com *.nr-data.net
+            blob: *.pmnts-sandbox.io *.rollbar.com fatzebra.statuspage.io *.iovation.com
+            data: *.googleapis.com *.gstatic.com *.newrelic.com *.bootstrapcdn.com www.google.com
+            pay.google.com *.google-analytics.com *.gravatar.com; font-src 'self' cdnjs.cloudflare.com
+            data: *.gstatic.com *.bootstrapcdn.com *.aexp-static.com; form-action 'self'
+            *.cardinalcommerce.com; frame-ancestors 'self'; frame-src 'self' fatzebra.statuspage.io
+            *.americanexpress.com www.google.com pay.google.com *.masterpass.com *.visa.com
+            *.mastercard.com; img-src 'self' *.visa.com data: *.googleapis.com *.gstatic.com
+            masterpass.com *.masterpass.com *.americanexpress.com *.google-analytics.com
+            *.gravatar.com; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.forter.com
+            *.nr-data.net *.pmnts-sandbox.io *.pmnts-staging.io *.rollbar.com fatzebra.statuspage.io
+            cdnjs.cloudflare.com *.iovation.com *.jquery.com *.newrelic.com *.googleapis.com
+            *.cardinalcommerce.com *.bootstrapcdn.com wasm-eval *.google-analytics.com
+            *.googletagmanager.com; script-src-attr 'unsafe-inline'; script-src-elem
+            'self' 'unsafe-inline' *.forter.com *.nr-data.net *.pmnts-sandbox.io *.rollbar.com
+            fatzebra.statuspage.io *.iovation.com *.jquery.com cdnjs.cloudflare.com *.pmnts-staging.io
+            *.aexp-static.com *.newrelic.com *.googleapis.com *.americanexpress.com www.google.com
+            pay.google.com *.visa.com *.masterpass.com *.mastercard.com *.google-analytics.com
+            *.gstatic.com *.bootstrapcdn.com; style-src 'self' 'unsafe-eval' 'unsafe-inline'
+            *.bootstrapcdn.com *.googleapis.com; style-src-attr 'unsafe-inline'; style-src-elem
+            'unsafe-inline' 'self' *.googleapis.com cdnjs.cloudflare.com *.bootstrapcdn.com;
+            worker-src blob:; report-uri https://fatzebra.report-uri.com/r/d/csp/wizard"
+        Nel:
+          - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
+        Report-To:
+          - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://fatzebra.report-uri.com/a/d/g"}],"include_subdomains":true}'
+      body:
+        encoding: UTF-8
+        string: '{"successful":true,"response":[{"domain":"example.com","status":"Active"},{"domain":"example2.com","status":"Active"}],"errors":[],"test":true}'
+      http_version:
+    recorded_at: Tue, 26 Mar 2024 03:14:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/fat_zebra/utilities/apple_pay/domain_spec.rb
+++ b/spec/lib/fat_zebra/utilities/apple_pay/domain_spec.rb
@@ -2,6 +2,27 @@ require 'spec_helper'
 
 describe FatZebra::Utilities::ApplePay::Domain do
 
+  describe '.list!', :vcr do
+    subject(:list) { FatZebra::Utilities::ApplePay::Domain.list! }
+
+    it "fetches the merchant domains" do
+      expect(list).to be_accepted
+      expect(list.data.length).to eq(2)
+      expect(list.data.first.raw).to eq(
+        {
+          "domain" => "example.com", 
+          "status" => "Active"
+        }
+      )
+      expect(list.data.last.raw).to eq(
+        {
+          "domain" => "example2.com", 
+          "status" => "Active"
+        }
+      )
+    end
+  end
+
   describe '.register!', :vcr do
     subject(:create) { FatZebra::Utilities::ApplePay::Domain.register!(domain, valid_payload) }
 

--- a/spec/lib/fat_zebra/utilities/apple_pay/domain_spec.rb
+++ b/spec/lib/fat_zebra/utilities/apple_pay/domain_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe FatZebra::Utilities::ApplePay::Domain do
 
-  describe '.list!', :vcr do
-    subject(:list) { FatZebra::Utilities::ApplePay::Domain.list! }
+  describe '.list', :vcr do
+    subject(:list) { FatZebra::Utilities::ApplePay::Domain.list }
 
     it "fetches the merchant domains" do
       expect(list).to be_accepted


### PR DESCRIPTION
A new endpoint has been added to return a merchant's Apple Pay (web) domains. This PR exposes that new endpoint in the Ruby gem.