### PR TITLE
Fix undefined variable on bundle install 

### DIFF
--- a/fat_zebra.gemspec
+++ b/fat_zebra.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.summary     = 'Fat Zebra payments gem - integrate your ruby app with Fat Zebra'
   s.description = 'Provides integration with the Fat Zebra internet payment gateway (www.fatzebra.com), including purchase, refund, auth, capture and recurring billing functionality.'
 
-  s.metadata['homepage_uri'] = spec.homepage
-  s.metadata['source_code_uri'] = spec.homepage
+  s.metadata['homepage_uri'] = s.homepage
+  s.metadata['source_code_uri'] = s.homepage
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec}/*`.split("\n")


### PR DESCRIPTION
Fixes this error on `bundle install`:
There was an error while loading `fat_zebra.gemspec`: undefined local variable or method `spec' for main:Object