### PR TITLE
Add ostruct as an explicit dependency.

### DIFF
--- a/fat_zebra.gemspec
+++ b/fat_zebra.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7'
 
+  s.add_dependency 'ostruct'
+
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.6'


### PR DESCRIPTION
It will not be bundled within Ruby's standard library from v3.5.0. Right now, Ruby 3.3 prints a deprecation warning whenever the fat_zebra gem is loaded, so this change removes the warning.