### PR TITLE
The usage of openstruct in this context isn't required and causes iss…

### DIFF
--- a/lib/fat_zebra/request.rb
+++ b/lib/fat_zebra/request.rb
@@ -165,7 +165,7 @@ module FatZebra
         if params[:proxy]
           URI(params[:proxy])
         else
-          OpenStruct.new
+          URI('')
         end
     end
 


### PR DESCRIPTION
…ues in later versions of Ruby3

## 📝 Description
<!-- Link to the ticket for this work -->
Jira ticket: https://fatzebra.atlassian.net/browse/PENG-387

<!-- What and why is this change being made? -->
Details of change
- Usage of openstruct here causes issues with ruby versions > 3.4
- An empty instance of the URI object returns the same `nil` values as the empty `OpenStruct`
